### PR TITLE
Update rank_SVs.pl

### DIFF
--- a/src/scripts/rank_SVs.pl
+++ b/src/scripts/rank_SVs.pl
@@ -61,7 +61,7 @@ while(<$KF>){
 	if($fg1 gt $fg2){
 		my $tmp = $fg1;
 		$fg1 = $fg2;
-		$fg2 = $fg1;
+		$fg2 = $tmp; #fix the swap bug
 	}
 	my $fusion = $fg1.":".$fg2;
 	next if(exists($known_fusions{$fusion}));


### PR DESCRIPTION
Fix the swap bug; Without the fix, some known fusion will be rated as LQ, e.g. TP53-JARID2