### PR TITLE
Update Transcript.pm

### DIFF
--- a/dependencies/lib/perl/Transcript.pm
+++ b/dependencies/lib/perl/Transcript.pm
@@ -68,6 +68,8 @@ sub get_feature {
 
 	return 'intergenic' if($bp > $self->end && $strand eq '+');
 	return 'intergenic' if($bp < $self->start && $strand eq '-');
+	return 'intergenic' if($bp < $self->start && $strand eq '+');#Tian
+        return 'intergenic' if($bp > $self->end && $strand eq '-');#Tian
 	my @tmp = @{$self->[EXONS]};
 	#print STDERR "--strand $strand\n";
 	foreach my $e (@tmp) {


### PR DESCRIPTION
Without the changes, if intergenic checkpoint (considering contig mapping direction) is on the upstream of a gene body, it is noted as intron; after the changes, it is noted as intergenic