### PR TITLE
Removed redundant coverage file size check from qc_cicero_sclips.sh

### DIFF
--- a/src/scripts/qc_cicero_sclips.sh
+++ b/src/scripts/qc_cicero_sclips.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # QCs the soft clips results for a run
 #
-# $1 = case EBN 
+# $1 = case EBN
 # $2 = data directory
 source qclib.sh
 
 CASE=$1
-DIR=$2 
+DIR=$2
 
 CaseDir="$DIR/$CASE"
 
@@ -27,9 +27,9 @@ if ls $CaseDir/$CASE.gene_info.txt >&2; then passtest; else aborttestcase; fi
 starttest GinfoSize
 cutoff=200
 while read file
-do 
+do
   if [ "`filesize $file`" -lt $cutoff ]
-  then 
+  then
     ls -l $file >&2
     failtestifactive Found at least one cover that was too small
   fi
@@ -46,11 +46,14 @@ do
   if [ -s $file ]
   then anynonempty=1
   fi
-  if [ "`filesize $file`" -lt $cutoff ]
-  then
-    anysmall=1
-    ls -l $file >&2
-  fi
+  ## B2P - Removed as it was causing false problems
+  ## (Note that we already know that the coverage file is non-empty,
+  ## and there is no header information)
+  # if [ "`filesize $file`" -lt $cutoff ]
+  # then
+  #   anysmall=1
+  #   ls -l $file >&2
+  # fi
 done< <(ls $CaseDir/$CASE.*.cover | sed '$d')
 if [ ! "$anynonempty" ]
 then failtest All cover files were empty


### PR DESCRIPTION
We found a number of instances (the only one that is still browsable is 3Fm2bAfu) where the check for file size on .cover files failed, although the data was good. Since qc_ciceros_sclips.sh has already checked if the coverage file is non-empty, and there's no header info, I commented out the file size check