### PR TITLE
added absolute path to final_qa steps for Slurm cluster

### DIFF
--- a/src/scripts/setup_cicero.sh
+++ b/src/scripts/setup_cicero.sh
@@ -225,16 +225,16 @@ init_step final_qa
 cat > `get_step_qc_script` <<EOF
 #!/bin/bash
 # QC:
-echo -n "" > final_qa.txt
+echo -n "" > $RUN_DIR/final_qa.txt
 anyfail=no
 while read case_bam
 do
   if ! qcquiet.sh `get_step_failed_qc_dir`/\$case_bam qc_cicerofilter.sh $DATA_DIR/ \$case_bam
   then 
     anyfail=yes
-    echo "FAIL \$case_bam" >> final_qa.txt
+    echo "FAIL \$case_bam" >> $RUN_DIR/final_qa.txt
   else
-    echo "PASS \$case_bam" >> final_qa.txt 
+    echo "PASS \$case_bam" >> $RUN_DIR/final_qa.txt 
   fi
 done < $RUN_DIR/config.txt
 if [ "\$anyfail" == "yes" ]

--- a/src/scripts/setup_cicero_itd.sh
+++ b/src/scripts/setup_cicero_itd.sh
@@ -300,16 +300,16 @@ init_step final_qa
 cat > `get_step_qc_script` <<EOF
 #!/bin/bash
 # QC:
-echo -n "" > final_qa.txt
+echo -n "" > $RUN_DIR/final_qa.txt
 anyfail=no
 while read case_bam
 do
   if ! qcquiet.sh `get_step_failed_qc_dir`/\$case_bam qc_cicerofilter.sh $DATA_DIR/ \$case_bam
   then 
     anyfail=yes
-    echo "FAIL \$case_bam" >> final_qa.txt
+    echo "FAIL \$case_bam" >> $RUN_DIR/final_qa.txt
   else
-    echo "PASS \$case_bam" >> final_qa.txt 
+    echo "PASS \$case_bam" >> $RUN_DIR/final_qa.txt 
   fi
 done < $RUN_DIR/config.txt
 if [ "\$anyfail" == "yes" ]

--- a/src/scripts/setup_cicero_post.sh
+++ b/src/scripts/setup_cicero_post.sh
@@ -150,16 +150,16 @@ init_step final_qa
 cat > `get_step_qc_script` <<EOF
 #!/bin/bash
 # QC:
-echo -n "" > final_qa.txt
+echo -n "" > $RUN_DIR/final_qa.txt
 anyfail=no
 while read case_bam 
 do
   if ! qcquiet.sh `get_step_failed_qc_dir`/\$case_bam qc_classification.sh $DATA_DIR/\$case_bam final_fusions final_fusions 
   then 
     anyfail=yes
-    echo "FAIL \$case_bam" >> final_qa.txt
+    echo "FAIL \$case_bam" >> $RUN_DIR/final_qa.txt
   else
-    echo "PASS \$case_bam" >> final_qa.txt 
+    echo "PASS \$case_bam" >> $RUN_DIR/final_qa.txt 
   fi
 done < $ANLS_CONFIG
 if [ "\$anyfail" == "yes" ]


### PR DESCRIPTION
Slurm job runner writes script outputs wrt to directory it runs a job from. Added absolute path to final_qa steps to prevent final_qa.txt from being written to my home directory, causing pipelines to fail.