### PR TITLE
Update RNApeg image invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Output is also written in UCSC .bed format, which can be used to visualize the j
 ### Running RNApeg via Docker
 
 ```bash
-docker run -v <outdir>:/results ghcr.io/stjude/rnapeg:latest RNApeg.sh -b bamfile -f fasta -r refflat
+docker run -v <outdir>:/results ghcr.io/stjude/rnapeg:latest -b bamfile -f fasta -r refflat
 ```
 
 - `fasta` reference genome; i.e. "Homo_sapiens/GRCh38_no_alt/FASTA/GRCh38_no_alt.fa" or "Homo_sapiens/GRCh37-lite/FASTA/GRCh37-lite.fa" from [Reference Files](#reference).

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ docker run -v <outdir>:/results ghcr.io/stjude/rnapeg:latest RNApeg.sh -b bamfil
 ### Running RNApeg via Singularity:
 
 ```bash
-singularity run --containall --bind <outdir>:/results docker://ghcr.io/stjude/rnapeg:latest RNApeg.sh -b bamfile -f fasta -r refflat
+singularity run --containall --bind <outdir>:/results docker://ghcr.io/stjude/rnapeg:latest -b bamfile -f fasta -r refflat
 ```
 
 You will also need to add `--bind` arguments to mount the file paths for `bamfile`, `fasta`, and `refflat` into the container. 


### PR DESCRIPTION
The updated RNApeg image provides the entrypoint, so specifying the script name is redundant and causes an error.