### PR TITLE
Fix sorting of blat results

### DIFF
--- a/src/perllib/CiceroExtTools.pm
+++ b/src/perllib/CiceroExtTools.pm
@@ -163,7 +163,7 @@ sub run {
 	croak "Please check BLAT server is correctly configured or running.\n" if($test != 0);
 	print STDERR "\ntest=$test\t", join(" ", ($self->{PRG}, $self->{BIT2_DIR}, $param{-QUERY}, $unsorted_psl, $options)), "\n" if($debug);
 	# Sort the output PSL file from BLAT.
-	`sort -k 11,11nr -k 10,10d -k 14,14d -k 1,1nr $unsorted_psl -o $psl_file`;
+	`sort -k 11,11nr -k 10,10d -k 1,1nr -k 14,14d $unsorted_psl -o $psl_file`;
 	if ($?){
 		my $err = $!;
 		print STDERR "Error sorting blat output: $err\n"; 
@@ -968,7 +968,7 @@ sub overhang_remapping {
 	print STDERR "test=$test\t", join(" ", ($blat_prefix, $contig_file, $unsorted_psl, $options)), "\n" if($debug);
 
 	return unless(-s $unsorted_psl);
-	`sort -k 10,10d -k 14,14d -k 1,1nr $unsorted_psl -o $psl_file`;
+	`sort -k 10,10d -k 1,1nr -k 14,14d $unsorted_psl -o $psl_file`;
 	if ($?){
 		my $err = $!;
 		print STDERR "Error sorting blat output: $err\n"; 


### PR DESCRIPTION
Sort blat results based on alignments score first; then sort based on chr name. This fix solved the issue that some EWSR1-FLI1 fusions are missed in final fusion file instead of reporting EWSR1 speudogene and FLI1 fusion.