### PR TITLE
fix: No unfiltered files shouldn't always fail

### DIFF
--- a/src/scripts/annotate.pl
+++ b/src/scripts/annotate.pl
@@ -174,8 +174,8 @@ if($internal) {
 		`cat $out_dir/*/unfiltered.internal.txt > $unfiltered_file`;
 		if ($?){
 			my $err = $!;
-			print STDERR "Error combining internal events: $err\n";
-			exit 2;
+			print STDERR "Warning: combining internal events failed: $err\n";
+			print STDERR "No events may be a valid result.\n";
 		}		
 	}
 }
@@ -184,8 +184,8 @@ else{
 		`cat $out_dir/*/unfiltered.fusion.txt > $unfiltered_file`;
 		if ($?){
 			my $err = $!;
-			print STDERR "Error combining fusion events: $err\n";
-			exit 3;
+			print STDERR "Warning: combining fusion events failed: $err\n";
+   			print STDERR "No events may be a valid result.\n";
 		}
 	}
 }


### PR DESCRIPTION
If no events were found upstream, there may be no output unfiltered files to combine. Change the message to a warning, instead of a failure, and proceed.